### PR TITLE
Formatting fix and nftables mention

### DIFF
--- a/learn/common-terms-and-concepts.md
+++ b/learn/common-terms-and-concepts.md
@@ -125,7 +125,7 @@ Port forwarding inspects and alters packet headers before it is routed to its ne
 
 Port forwarding is a function of your firewall. Commonly at the router or other network gateway.
 
-Linux has one firewall called `iptables` with many frontends or management packages available for it. BSD-based firewalls are `pf`, `ipfw, and `IPFilter`. The Windows firewall consists of a scarecrow holding a sign saying: "plz no tresspass".
+Linux has one firewall called `iptables` with many frontends or management packages available for it. BSD-based firewalls are `pf`, `ipfw`, and `IPFilter`. The Windows firewall consists of a scarecrow holding a sign saying: "plz no tresspass".
 
 ## Containers
 

--- a/learn/common-terms-and-concepts.md
+++ b/learn/common-terms-and-concepts.md
@@ -125,7 +125,7 @@ Port forwarding inspects and alters packet headers before it is routed to its ne
 
 Port forwarding is a function of your firewall. Commonly at the router or other network gateway.
 
-Linux has one firewall called `iptables` with many frontends or management packages available for it. BSD-based firewalls are `pf`, `ipfw`, and `IPFilter`. The Windows firewall consists of a scarecrow holding a sign saying: "plz no tresspass".
+Linux has two firewalls called `iptables` and `nftables`, with many frontends or management packages available for them. BSD-based firewalls are `pf`, `ipfw`, and `IPFilter`. The Windows firewall consists of a scarecrow holding a sign saying: "plz no tresspass".
 
 ## Containers
 


### PR DESCRIPTION
Hi, reading through the great *Common Terms and Concepts*, I spotted a formatting typo and thought it would make sense to mention `iptables`' successor, `nftables`. Feel free to just cherry-pick the typo fix if you don't care for nftables 😉
Cheers