### PR TITLE
Add Project Management section to self-hosted alternatives

### DIFF
--- a/learn/self-hosted-alternatives-to-popular-services-and-providers.md
+++ b/learn/self-hosted-alternatives-to-popular-services-and-providers.md
@@ -74,6 +74,15 @@ Software for operating a photo gallery.
 - [Zenphoto](http://www.zenphoto.org/)
 - [Piwigo](http://piwigo.org/)
 
+## Project Management
+
+Software for tracking issues, sprints, roadmaps, and team work.
+
+- [OpenProject](https://www.openproject.org/) | Project management with Gantt charts, agile boards, and time tracking.
+- [Plane](https://plane.so/) | Issues, cycles, modules, and roadmaps with a modern interface.
+- [Taiga](https://www.taiga.io/) | Agile project management for cross-functional teams using Scrum and Kanban.
+- [Windshift](https://windshift.sh/) | A self-hosted Jira alternative for work management.
+
 ## Wiki Software
 
 You own personal knowledge base!


### PR DESCRIPTION
## Summary
- Adds a new **Project Management** section to `learn/self-hosted-alternatives-to-popular-services-and-providers.md` (the page currently has no PM category at all).
- Seeds it with four entries listed alphabetically: OpenProject, Plane, Taiga, Windshift.
- Slotted between Photo Galleries and Wiki Software to match the page's loose alphabetical ordering.

## Disclosure
I'm affiliated with Windshift (one of the listed projects). I deliberately included three established alternatives (OpenProject, Plane, Taiga) so the section isn't a single-vendor entry. Happy to adjust wording, drop Windshift, or trim the list if maintainers prefer.